### PR TITLE
Added Camera Smoothing

### DIFF
--- a/CamUnsnap/CUSController.cs
+++ b/CamUnsnap/CUSController.cs
@@ -9,6 +9,7 @@ using EFT.Communications;
 using MonoMod.RuntimeDetour;
 using System.Threading.Tasks;
 using System.Collections.Generic;
+using System.Numerics;
 
 namespace CamUnsnap
 {
@@ -97,6 +98,9 @@ namespace CamUnsnap
 
         float CameraSensitivity
         { get => Plugin.CameraSensitivity.Value; }
+        
+        float CameraSmoothing
+        { get => Plugin.CameraSmoothing.Value; }
 
         GameObject commonUI
         { get => MonoBehaviourSingleton<CommonUI>.Instance.gameObject; }
@@ -174,7 +178,8 @@ namespace CamUnsnap
                 mCamUnsnapped = value;
             }
         }
-
+        private Vector2 smoothedMouseDelta;
+        private Vector2 currentMouseDelta;
         void Update()
         {
             if (Input.GetKeyDown(Plugin.ToggleCameraSnap.Value.MainKey)) 
@@ -343,10 +348,17 @@ namespace CamUnsnap
 
                     if (CamViewInControl)
                     {
-                        float newRotationX = gameCamera.transform.localEulerAngles.y + Input.GetAxis("Mouse X") * CameraSensitivity;
-                        float newRotationY = gameCamera.transform.localEulerAngles.x - Input.GetAxis("Mouse Y") * CameraSensitivity;
+
+                        currentMouseDelta.x = Input.GetAxis("Mouse X") * CameraSensitivity;
+                        currentMouseDelta.y = Input.GetAxis("Mouse Y") * CameraSensitivity;
+
+                        smoothedMouseDelta = Vector2.Lerp(smoothedMouseDelta, currentMouseDelta, CameraSmoothing);
+
+                        float newRotationX = gameCamera.transform.localEulerAngles.y + smoothedMouseDelta.x;
+                        float newRotationY = gameCamera.transform.localEulerAngles.x - smoothedMouseDelta.y;
 
                         gameCamera.transform.localEulerAngles = new Vector3(newRotationY, newRotationX, 0f);
+
                     }
 
                     if (Input.GetKey(Plugin.RotateLeft.Value.MainKey))

--- a/CamUnsnap/Plugin.cs
+++ b/CamUnsnap/Plugin.cs
@@ -40,6 +40,7 @@ namespace CamUnsnap
         internal static ConfigEntry<float> Gamespeed;
         internal static ConfigEntry<float> MovementSpeed;
         internal static ConfigEntry<float> CameraSensitivity;
+        internal static ConfigEntry<float> CameraSmoothing;
         internal static ConfigEntry<float> FastMoveMult;
         internal static ConfigEntry<int> CameraFOV;
         internal static ConfigEntry<bool> ImmuneInCamera;
@@ -77,6 +78,7 @@ namespace CamUnsnap
             CameraFOV = Config.Bind(CameraSettingsSectionName, "Camera FOV", 75, new ConfigDescription("The FOV value of the camera while unsnaped", new AcceptableValueRange<int>(1, 200)));
             MovementSpeed = Config.Bind(CameraSettingsSectionName, "CameraMoveSpeed", 10f, new ConfigDescription("How fast you want the camera to move", new AcceptableValueRange<float>(0.01f, 100f)));
             CameraSensitivity = Config.Bind(CameraSettingsSectionName, "Camera Sensitivity", 10f, new ConfigDescription("How fast you want the camera viewport to move while slaved", new AcceptableValueRange<float>(0.0f, 100f)));
+            CameraSmoothing = Config.Bind(CameraSettingsSectionName, "Mouse Smoothing", 10f, new ConfigDescription("The amount of smoothing you want applied to the mouse in camera mode. (Lower is smoother)", new AcceptableValueRange<float>(0.0001f, 1f)));
             Gamespeed = Config.Bind(CameraSettingsSectionName, "Set Gamespeed", 1f, new ConfigDescription("What gamespeed you want to set the gameworld to when pressing the Change Gamespeed bind !WARNING! Changing the gamespeed for too long can cause weird (but temporary) side effects", new AcceptableValueRange<float>(0f, 1f)));
             FastMoveMult = Config.Bind(CameraSettingsSectionName, "Set Fast Movement Multiplier", 2f, new ConfigDescription("The value that the camera movement speed is multiplied by while the move fast key is held", new AcceptableValueRange<float>(0f, 100f)));
             RotateUsesSens = Config.Bind(CameraSettingsSectionName, "Rotation speed inherits Camera Sensitivity", false, "If true, the camera rotation speed is multiplied by the Camera Sensitivity value, otherwise, the camera is rotated by only 1 degree per frame");


### PR DESCRIPTION
# Smooth Camera

## Description
Added a new feature called "Smooth camera" that provides smooth, consistent, and non-stuttery shots for cinematic purposes.

### Why I did it?
I'm working on some cinematic shots in tarkov, and low sensitivity was not doing it for me. I was getting inconsistent shots, and such. Adding this quick change can fix that, and make it optional for others if they don't want it (set it to 1, or change it to a toggle on/off with a slider).

The Smooth camera change will smooth out the camera movement by using Vector2.Lerp to provide a more fluid look. 